### PR TITLE
fix cpp default https bug

### DIFF
--- a/cpp-realtime-asr/CMakeLists.txt
+++ b/cpp-realtime-asr/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_VERBOSE_MAKEFILE on)
 set(CMAKE_CXX_STANDARD 11)
 
-option(WITH_SSL_OPTION "Using wss:\\ instead of ws:\\" OFF)
+option(WITH_SSL_OPTION "Using wss:\\ instead of ws:\\" ON)
 
 set(GCC_EXPECTED_VERSION 4.8.2)
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS GCC_EXPECTED_VERSION)

--- a/cpp-realtime-asr/const.h
+++ b/cpp-realtime-asr/const.h
@@ -10,7 +10,9 @@ const std::string APPKEY = "g8eBUxxxxGmgxLFYviL";
 // 修改其它识别语言或者识别模型
 const int DEV_PID = 15372;
 const std::string HOST = "vop.baidu.com";
-const int PORT = 80;
+
+// ssl to 443
+const int PORT = 443;
 const std::string PATH = "/realtime_asr";
 
 }


### PR DESCRIPTION
目前已经不支持 ws方式，默认请求参数需要调整为 wss
默认端口443、WITH_SSL_OPTION默认 ON
